### PR TITLE
Handle comments on chapter title heading line

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -262,7 +262,7 @@ impl DocFile {
         // Try to find an h1 heading
         for line in lines {
             if line.starts_with("# ") {
-                let mut title = .split_once("# ").expect("Chapter title heading not found.").1;
+                let (mut title, _) = line.split_once("# ").expect("Chapter title heading not found.");
                 if let Some((title_without_comment, _)) = title.split_once("<!--") {
                     title = title_without_comment;
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -262,7 +262,10 @@ impl DocFile {
         // Try to find an h1 heading
         for line in lines {
             if line.starts_with("# ") {
-                let title = line.trim_start_matches("# ").to_string();
+                let mut title = .split_once("# ").expect("Chapter title heading not found.").1;
+                if let Some((title_without_comment, _)) = title.split_once("<!--") {
+                    title = title_without_comment;
+                }
                 return Some(Self::new(title, path.to_path_buf(), depth));
             }
         }


### PR DESCRIPTION
Some tools, like Prettier in combination with Markdown-All-In-One require configuration comments on the pertinent line, rather than the preceding line. Since `mdbook-autosummary` doesn't use a Markdown parser, it produces bad output on this input. Example:

```markdown
# Introduction<!-- omit in toc --><!-- LTeX: language=en -->
```